### PR TITLE
trim spaces from did when resolving handle over http

### DIFF
--- a/pkg/oatproxy/resolution.go
+++ b/pkg/oatproxy/resolution.go
@@ -61,7 +61,7 @@ func ResolveHandle(ctx context.Context, handle string) (string, error) {
 			return "", err
 		}
 
-		maybeDid := string(b)
+		maybeDid := strings.TrimSpace(string(b))
 
 		if _, err := syntax.ParseDID(maybeDid); err != nil {
 			return "", fmt.Errorf("unable to resolve handle")


### PR DESCRIPTION
many text editors add trailing newlines to files, so in practice atproto-did files often include spacing.